### PR TITLE
Resolving dependency issue by removing libb2 from CmakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,5 +33,4 @@ add_executable(hpfs
 )
 target_link_libraries(hpfs
     libfuse3.so.3
-    libb2.so
     libblake3.so)

--- a/src/vfs.hpp
+++ b/src/vfs.hpp
@@ -5,6 +5,7 @@
 #include <sys/stat.h>
 #include <unordered_map>
 #include <vector>
+#include <cstring>
 #include "logger.hpp"
 
 namespace vfs
@@ -37,6 +38,12 @@ namespace vfs
 
         // Max file size that has been there for this vnode throughout the log history.
         size_t max_size = 0;
+
+        vnode()
+        {
+            memset(&st, 0, sizeof(struct stat));
+            memset(&mmap, 0, sizeof(struct vnode_mmap));
+        }
     };
 
     typedef std::unordered_map<std::string, vnode> vnode_map;


### PR DESCRIPTION
1. Removing libb2 from CmakeLists which is a blake2 library which is no longer necessary
2. Minor changes were done during Valgrind memory testing