### PR TITLE
Introduce state hash checkpoint index in hpfs.

### DIFF
--- a/src/audit.cpp
+++ b/src/audit.cpp
@@ -427,6 +427,7 @@ namespace hpfs::audit
         {
             return 0;
         }
+        // Return if the given hash is an empty hash.
         if (state_hash == hmap::hasher::h32_empty)
             return -1;
 

--- a/src/audit.cpp
+++ b/src/audit.cpp
@@ -299,7 +299,7 @@ namespace hpfs::audit
             release_lock(header_lock) == -1)
         {
             LOG_ERROR << errno << ": Error updating header during append log.";
-            return -1;
+            return 0;
         }
 
         // Saving the starting offset of the log record.

--- a/src/audit.hpp
+++ b/src/audit.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <optional>
 #include "hpfs.hpp"
+#include "hmap/hasher.hpp"
 
 namespace hpfs::audit
 {
@@ -51,6 +52,7 @@ namespace hpfs::audit
         size_t vpath_len;
         size_t payload_len;
         size_t block_data_len;
+        hmap::hasher::h32 state_hash;
     };
 
     struct log_record
@@ -65,6 +67,7 @@ namespace hpfs::audit
         size_t payload_len;
         off_t block_data_offset;
         size_t block_data_len;
+        hmap::hasher::h32 state_hash;
     };
 
     struct op_write_payload_header
@@ -114,11 +117,12 @@ namespace hpfs::audit
         int release_lock(struct flock &lock);
         int read_header();
         int commit_header();
-        int append_log(std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
+        int append_log(std::string_view vpath, const FS_OPERATION operation, off_t &log_rec_start_offset, const iovec *payload_buf = NULL,
                        const iovec *block_bufs = NULL, const int block_buf_count = 0);
         int read_log_at(const off_t offset, off_t &next_offset, log_record &record);
         int read_payload(std::vector<uint8_t> &payload, const log_record &record);
         int purge_log(const log_record &record);
+        int update_log_record(const off_t log_rec_start_offset, const hmap::hasher::h32 state_hash);
         ~audit_logger();
     };
 

--- a/src/audit.hpp
+++ b/src/audit.hpp
@@ -117,12 +117,12 @@ namespace hpfs::audit
         int release_lock(struct flock &lock);
         int read_header();
         int commit_header();
-        int append_log(std::string_view vpath, const FS_OPERATION operation, off_t &log_rec_start_offset, const iovec *payload_buf = NULL,
+        off_t append_log(log_record_header& log_record, std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
                        const iovec *block_bufs = NULL, const int block_buf_count = 0);
         int read_log_at(const off_t offset, off_t &next_offset, log_record &record);
         int read_payload(std::vector<uint8_t> &payload, const log_record &record);
         int purge_log(const log_record &record);
-        int update_log_record(const off_t log_rec_start_offset, const hmap::hasher::h32 state_hash);
+        int update_log_record(const off_t log_rec_start_offset, const hmap::hasher::h32 state_hash,  log_record_header &rh);
         ~audit_logger();
     };
 

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -297,8 +297,8 @@ namespace hpfs::hmap::tree
 
     hmap::hasher::h32 hmap_tree::get_root_hash()
     {
-        store::vnode_hmap *node_hmap;
-        if (get_vnode_hmap(&node_hmap, ROOT_VPATH) == -1)
+        store::vnode_hmap *node_hmap = store.find_hash_map(ROOT_VPATH);
+        if (node_hmap == NULL)
         {
             return hmap::hasher::h32_empty;
         }

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -295,6 +295,16 @@ namespace hpfs::hmap::tree
         return 0;
     }
 
+    hmap::hasher::h32 hmap_tree::get_root_hash()
+    {
+        store::vnode_hmap *node_hmap;
+        if (get_vnode_hmap(&node_hmap, ROOT_VPATH) == -1)
+        {
+            return hmap::hasher::h32_empty;
+        }
+        return node_hmap->node_hash;
+    }
+
     hmap_tree::~hmap_tree()
     {
         if (initialized && !moved)

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -36,6 +36,7 @@ namespace hpfs::hmap::tree
                                    const off_t update_offset, const size_t update_size);
         int apply_vnode_delete(const std::string &vpath);
         int apply_vnode_rename(const std::string &from_vpath, const std::string &to_vpath);
+        hmap::hasher::h32 get_root_hash();
         ~hmap_tree();
     };
 

--- a/src/vfs/fuse_adapter.cpp
+++ b/src/vfs/fuse_adapter.cpp
@@ -63,7 +63,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_create(vpath) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -90,7 +90,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_delete(vpath) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -120,7 +120,7 @@ namespace hpfs::vfs
                 if (log_rec_start_offset == 0 ||
                      virt_fs.build_vfs() == -1 ||
                      (htree && htree->apply_vnode_delete(to_vpath) == -1) ||
-                     (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+                     (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
                     return -1;
             }
         }
@@ -131,7 +131,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_rename(from_vpath, to_vpath) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -154,7 +154,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_delete(vpath) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -177,7 +177,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_create(vpath) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -231,7 +231,7 @@ namespace hpfs::vfs
         if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_update(vpath, *vn, wr_start, wr_size) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return wr_size;
@@ -277,7 +277,7 @@ namespace hpfs::vfs
             (htree && htree->apply_vnode_update(vpath, *vn,
                                                 MIN(new_size, current_size),
                                                 MAX(0, new_size - current_size)) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
+            (htree && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;

--- a/src/vfs/fuse_adapter.cpp
+++ b/src/vfs/fuse_adapter.cpp
@@ -117,10 +117,10 @@ namespace hpfs::vfs
             {
                 audit::log_record_header rh;
                 off_t log_rec_start_offset = logger.append_log(rh, to_vpath, hpfs::audit::FS_OPERATION::UNLINK);
-                if ((log_rec_start_offset == 0 ||
+                if (log_rec_start_offset == 0 ||
                      virt_fs.build_vfs() == -1 ||
                      (htree && htree->apply_vnode_delete(to_vpath) == -1) ||
-                     (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1)))
+                     (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
                     return -1;
             }
         }

--- a/src/vfs/fuse_adapter.cpp
+++ b/src/vfs/fuse_adapter.cpp
@@ -57,11 +57,13 @@ namespace hpfs::vfs
         if (vn)
             return -EEXIST;
 
-        off_t log_rec_start_offset;
+        audit::log_record_header rh;
         iovec payload{&mode, sizeof(mode)};
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::MKDIR, log_rec_start_offset, &payload) == -1 ||
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::MKDIR, &payload);
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_create(vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_create(vpath) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -83,10 +85,12 @@ namespace hpfs::vfs
         if (!children.empty())
             return -ENOTEMPTY;
 
-        off_t log_rec_start_offset;
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::RMDIR, log_rec_start_offset) == -1 ||
+        audit::log_record_header rh;
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::RMDIR);
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_delete(vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_delete(vpath) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -108,18 +112,26 @@ namespace hpfs::vfs
             vfs::vnode *vn_to;
             if (virt_fs.get_vnode(to_vpath, &vn_to) == -1)
                 return -1;
-            off_t log_rec_start_offset;
-            if (vn_to && (logger.append_log(to_vpath, hpfs::audit::FS_OPERATION::UNLINK, log_rec_start_offset) == -1 ||
-                          virt_fs.build_vfs() == -1 ||
-                          (htree && htree->apply_vnode_delete(to_vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1)))
-                return -1;
+
+            if (vn_to)
+            {
+                audit::log_record_header rh;
+                off_t log_rec_start_offset = logger.append_log(rh, to_vpath, hpfs::audit::FS_OPERATION::UNLINK);
+                if ((log_rec_start_offset == 0 ||
+                     virt_fs.build_vfs() == -1 ||
+                     (htree && htree->apply_vnode_delete(to_vpath) == -1) ||
+                     (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1)))
+                    return -1;
+            }
         }
 
-        off_t log_rec_start_offset;
+        audit::log_record_header rh;
         iovec payload{(void *)to_vpath, strlen(to_vpath) + 1};
-        if (logger.append_log(from_vpath, hpfs::audit::FS_OPERATION::RENAME, log_rec_start_offset, &payload) == -1 ||
+        off_t log_rec_start_offset = logger.append_log(rh, from_vpath, hpfs::audit::FS_OPERATION::RENAME, &payload);
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_rename(from_vpath, to_vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_rename(from_vpath, to_vpath) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -136,10 +148,13 @@ namespace hpfs::vfs
         if (!vn)
             return -ENOENT;
 
-        off_t log_rec_start_offset;
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::UNLINK, log_rec_start_offset) == -1 ||
+        audit::log_record_header rh;
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::UNLINK);
+
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_delete(vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_delete(vpath) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -156,11 +171,13 @@ namespace hpfs::vfs
         if (vn)
             return -EEXIST;
 
-        off_t log_rec_start_offset;
+        audit::log_record_header rh;
         iovec payload{&mode, sizeof(mode)};
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::CREATE, log_rec_start_offset, &payload) == -1 ||
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::CREATE, &payload);
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_create(vpath) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_create(vpath) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;
@@ -207,12 +224,14 @@ namespace hpfs::vfs
         hpfs::audit::op_write_payload_header wh{wr_size, wr_start, block_buf_size,
                                                 block_buf_start, (wr_start - block_buf_start)};
 
-        off_t log_rec_start_offset;
+        audit::log_record_header rh;
         iovec payload{&wh, sizeof(wh)};
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::WRITE, log_rec_start_offset, &payload,
-                              block_buf_segs.data(), block_buf_segs.size()) == -1 ||
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::WRITE, &payload,
+                                                       block_buf_segs.data(), block_buf_segs.size());
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
-            (htree && htree->apply_vnode_update(vpath, *vn, wr_start, wr_size) == -1) || (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (htree && htree->apply_vnode_update(vpath, *vn, wr_start, wr_size) == -1) ||
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return wr_size;
@@ -249,15 +268,16 @@ namespace hpfs::vfs
             th.mmap_block_size = block_buf_size;
         }
 
-        off_t log_rec_start_offset;
+        audit::log_record_header rh;
         iovec payload{&th, sizeof(th)};
-        if (logger.append_log(vpath, hpfs::audit::FS_OPERATION::TRUNCATE, log_rec_start_offset, &payload,
-                              block_buf_segs.data(), block_buf_segs.size()) == -1 ||
+        off_t log_rec_start_offset = logger.append_log(rh, vpath, hpfs::audit::FS_OPERATION::TRUNCATE, &payload,
+                                                       block_buf_segs.data(), block_buf_segs.size());
+        if (log_rec_start_offset == 0 ||
             virt_fs.build_vfs() == -1 ||
             (htree && htree->apply_vnode_update(vpath, *vn,
                                                 MIN(new_size, current_size),
                                                 MAX(0, new_size - current_size)) == -1) ||
-            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash()) == -1))
+            (ctx.hmap_enabled && logger.update_log_record(log_rec_start_offset, htree->get_root_hash(), rh) == -1))
             return -1;
 
         return 0;


### PR DESCRIPTION
The state hash of hpfs is saved along with every log record if hmap is enabled.