### PR TITLE
Struct Packing and Support only Littleendian

### DIFF
--- a/src/audit.hpp
+++ b/src/audit.hpp
@@ -51,7 +51,7 @@ namespace hpfs::audit
 
         // Last checkpoint offset (inclusive of the checkpointed log record).
         off_t last_checkpoint;
-    };
+    }__attribute__((packed));
 
     struct log_record_header
     {
@@ -61,7 +61,7 @@ namespace hpfs::audit
         size_t payload_len;
         size_t block_data_len;
         hmap::hasher::h32 state_hash;
-    };
+    }__attribute__((packed));
 
     struct log_record
     {

--- a/src/hpfs.cpp
+++ b/src/hpfs.cpp
@@ -23,6 +23,13 @@ namespace hpfs
 
     int init(int argc, char **argv)
     {
+        int n = 1;
+        if(*(char *)&n != 1)
+        {
+            std::cerr << "Bigendian not supported.\n";
+            return -1;
+        }
+
         if (parse_cmd(argc, argv) == -1)
         {
             std::cerr << "Invalid arguments.\n";

--- a/src/hpfs.cpp
+++ b/src/hpfs.cpp
@@ -23,7 +23,7 @@ namespace hpfs
 
     int init(int argc, char **argv)
     {
-        int n = 1;
+        const int n = 1;
         if(*(char *)&n != 1)
         {
             std::cerr << "Bigendian not supported.\n";


### PR DESCRIPTION
* Struct packing is introduced to structs that persists in memory
* The code will exit if system is not littleendian