### PR TITLE
Log offset index implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(hpfs
     src/util.cpp
     src/tracelog.cpp
     src/audit/audit.cpp
+    src/audit/logger_index.cpp
     src/vfs/virtual_filesystem.cpp
     src/vfs/seed_path_tracker.cpp
     src/vfs/fuse_adapter.cpp
@@ -29,7 +30,6 @@ add_executable(hpfs
     src/session.cpp
     src/hpfs.cpp
     src/main.cpp
-    src/audit/logger_index.cpp
 )
 target_link_libraries(hpfs
     pthread

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ add_executable(hpfs
     src/inodes.cpp
     src/util.cpp
     src/tracelog.cpp
-    src/audit.cpp
+    src/audit/audit.cpp
     src/vfs/virtual_filesystem.cpp
     src/vfs/seed_path_tracker.cpp
     src/vfs/fuse_adapter.cpp
@@ -29,6 +29,7 @@ add_executable(hpfs
     src/session.cpp
     src/hpfs.cpp
     src/main.cpp
+    src/audit/logger_index.cpp
 )
 target_link_libraries(hpfs
     pthread

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -8,9 +8,9 @@
 #include <iostream>
 #include <vector>
 #include <optional>
-#include "audit.hpp"
 #include "../util.hpp"
 #include "../tracelog.hpp"
+#include "audit.hpp"
 #include "../hpfs.hpp"
 
 namespace hpfs::audit

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -8,10 +8,10 @@
 #include <iostream>
 #include <vector>
 #include <optional>
-#include "util.hpp"
-#include "tracelog.hpp"
 #include "audit.hpp"
-#include "hpfs.hpp"
+#include "../util.hpp"
+#include "../tracelog.hpp"
+#include "../hpfs.hpp"
 
 namespace hpfs::audit
 {
@@ -26,7 +26,7 @@ namespace hpfs::audit
             logger.reset();
             return -1;
         }
-        
+
         return 0;
     }
 

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -6,8 +6,8 @@
 #include <fcntl.h>
 #include <vector>
 #include <optional>
-#include "hpfs.hpp"
-#include "hmap/hasher.hpp"
+#include "../hpfs.hpp"
+#include "../hmap/hasher.hpp"
 
 namespace hpfs::audit
 {

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -162,9 +162,10 @@ namespace hpfs::audit::logger_index
     */
     int index_check_write(std::string_view query)
     {
+        // If logger index isn't initialized return no entry.
         if (query == INDEX_UPDATE_QUERY)
             return initialized ? update_log_index() : -ENOENT;
-        
+
         return 1;
     }
 
@@ -176,6 +177,7 @@ namespace hpfs::audit::logger_index
     */
     int index_check_open(std::string_view query)
     {
+        // If logger index isn't initialized return no entry.
         if (query == INDEX_UPDATE_QUERY)
             return initialized ? 0 : -ENOENT;
 
@@ -193,9 +195,10 @@ namespace hpfs::audit::logger_index
     {
         if (query == INDEX_UPDATE_QUERY)
         {
+            // If logger index isn't initialized return no entry.
             if (!initialized)
                 return -ENOENT;
-            
+
             if (fstat(fd, stbuf) == -1)
             {
                 LOG_ERROR << errno << ": Error in stat of index file.";

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -4,6 +4,12 @@
 #include "../tracelog.hpp"
 #include "../util.hpp"
 
+/**
+ * Log index file keeps offset and the root_hash of log records.
+ * Format - [log1_off,log1_r_hash,log2_off,log2_r_hash,log3_off,log3_r_hash...]
+ * When a ledger created in the hpcore, offset and root_hash of the latest hpfs log is recorded.
+ * So, the corresponding offsets for the ledger logs can be obtained from the index file by the ledger seq number.
+*/
 namespace hpfs::audit::logger_index
 {
     constexpr int FILE_PERMS = 0644;
@@ -43,11 +49,8 @@ namespace hpfs::audit::logger_index
         if (fstat(fd, &st) == -1)
         {
             LOG_ERROR << errno << ": Error in stat of index file.";
-            if (fd != -1)
-            {
-                close(fd);
-                fd = -1;
-            }
+            close(fd);
+            fd = -1;
             logger.reset();
             return -1;
         }
@@ -74,7 +77,7 @@ namespace hpfs::audit::logger_index
     int update_log_index()
     {
         // If logger isn't initialized show error.
-        if (!initialized && !logger.has_value())
+        if (!initialized)
         {
             LOG_ERROR << errno << ": Index hasn't been initialized properly.";
             return -1;
@@ -185,7 +188,7 @@ namespace hpfs::audit::logger_index
     }
 
     /**
-     * Checks getattr requests for any session-related metadata activity.
+     * Checks getattr requests for any index-related metadata activity.
      * @param query Query passed from the outside.
      * @param stbuf Stat to be populated if this is a index control
      * @return 0 if request succesfully was interpreted by index control. 1 if the request

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -1,0 +1,162 @@
+
+#include "logger_index.hpp"
+#include "audit.hpp"
+#include "../tracelog.hpp"
+#include "../util.hpp"
+
+namespace hpfs::audit::logger_index
+{
+    constexpr int FILE_PERMS = 0644;
+    constexpr uint16_t HPFS_VERSION = 1;
+    constexpr const char *INDEX_UPDATE_FILE = "/::hpfs.log.update.index";
+
+    int fd = 0;    // The index file fd used throughout the session.
+    off_t eof = 0; // End of file (End offset of index file).
+    std::optional<audit::audit_logger> logger;
+
+    /**
+     * Initialize the log index file.
+     * @param file_path Path of the log index file.
+     * @return Returns 0 on success, -1 on error.
+    */
+    int init(std::string_view file_path)
+    {
+        // First initialize the logger.
+        if (audit::audit_logger::create(logger, audit::LOG_MODE::RO, ctx.log_file_path) == -1)
+        {
+            LOG_ERROR << errno << ": Error in opening log file.";
+            logger.reset();
+            return -1;
+        }
+
+        // Open or create the index file.
+        const int res = open(file_path.data(), O_CREAT | O_RDWR | O_APPEND, FILE_PERMS);
+        if (res == -1)
+        {
+            LOG_ERROR << errno << ": Error in opening index file.";
+            logger.reset();
+            return -1;
+        }
+        fd = res;
+
+        struct stat st;
+        if (fstat(fd, &st) == -1)
+        {
+            LOG_ERROR << errno << ": Error in stat of index file.";
+            close(fd);
+            logger.reset();
+            return -1;
+        }
+
+        eof = st.st_size;
+
+        return 0;
+    }
+
+    void deinit()
+    {
+        close(fd);
+        logger.reset();
+    }
+
+    /**
+     * Updates the log index file with the offset of last log record and it's root hash.
+     * @return Return 0 on success, -1 on error.
+    */
+    int update_log_index()
+    {
+        // If logger isn't initialized show error.
+        if (!logger.has_value())
+        {
+            LOG_ERROR << errno << ": Logger isn't opened.";
+            return -1;
+        }
+
+        // First read the header from the log file.
+        if (logger->read_header() == -1)
+        {
+            LOG_ERROR << errno << ": Error in reading the log header.";
+            return -1;
+        }
+
+        // Read the log header to get the offset.
+        const hpfs::audit::log_header header = logger->get_header();
+
+        // Read the last log record
+        off_t next_offset;
+        hpfs::audit::log_record log_record;
+        if (logger->read_log_at(header.last_record, next_offset, log_record) == -1)
+        {
+            LOG_ERROR << errno << ": Error in reading last log record.";
+            return -1;
+        }
+
+        // Offset of current log is the last log records offset. So it is taken from the log header.
+        // Convert offset to big endian before persisting to the disk.
+        uint8_t offset[8];
+        util::uint64_to_bytes(offset, header.last_record);
+
+        struct iovec iov_vec[2];
+        iov_vec[0].iov_base = offset;
+        iov_vec[0].iov_len = sizeof(offset);
+
+        iov_vec[1].iov_base = &(log_record.state_hash);
+        iov_vec[1].iov_len = sizeof(log_record.state_hash);
+
+        if (writev(fd, iov_vec, 2) == -1)
+        {
+            LOG_ERROR << errno << ": Error writing to log index file.";
+            return -1;
+        }
+
+        eof += sizeof(offset) + sizeof(log_record.state_hash);
+        return 0;
+    }
+
+    /**
+     * Reading the last root hash from the index file.
+     * @param root_hash Last root hash.
+     * @return Returns 0 on success, -1 on error.
+    */
+    int read_last_root_hash(hmap::hasher::h32 &root_hash)
+    {
+        // If index file is empty return empty hash.
+        if (eof == 0)
+        {
+            root_hash = hmap::hasher::h32_empty;
+            return 0;
+        }
+
+        // Read from the end of the file.
+        if (pread(fd, &root_hash, sizeof(root_hash), eof - sizeof(root_hash)) < sizeof(root_hash))
+        {
+            LOG_ERROR << errno << ": Error when reading index file.";
+            return -1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Get the last sequence number from the index.
+     * @return Returns the seqence number, 0 if file is empty.
+    */
+    uint64_t get_last_seq_no()
+    {
+        return eof / (sizeof(uint64_t) + sizeof(hmap::hasher::h32));
+    }
+
+    /**
+     * Handles the log index control signals.
+     * @param query Query provided from the outside.
+     * @return Returns 0 on success, -1 error, 1 if invalid control.
+    */
+    int handle_log_index_control(std::string_view query)
+    {
+        if (query == INDEX_UPDATE_FILE)
+            return update_log_index();
+        
+        return 1;
+    }
+
+} // namespace hpfs::logger_index

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -1,0 +1,23 @@
+#ifndef _HPFS_AUDIT_LOGGER_INDEX_
+#define _HPFS_AUDIT_LOGGER_INDEX_
+
+#include <string>
+#include <optional>
+#include "../hmap/hasher.hpp"
+
+namespace hpfs::audit::logger_index
+{
+    int init(std::string_view file_path);
+
+    void deinit();
+
+    int update_log_index();
+
+    int read_last_root_hash(hmap::hasher::h32 &root_hash);
+
+    uint64_t get_last_seq_no();
+
+    int handle_log_index_control(std::string_view query);
+} // namespace hpfs::audit::logger_index
+
+#endif

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -23,6 +23,7 @@ namespace hpfs::audit::logger_index
     int index_check_open(std::string_view query);
 
     int index_check_getattr(std::string_view query, struct stat *stbuf);
+    
 } // namespace hpfs::audit::logger_index
 
 #endif

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <optional>
+#include <sys/stat.h>
 #include "../hmap/hasher.hpp"
 
 namespace hpfs::audit::logger_index
@@ -17,7 +18,11 @@ namespace hpfs::audit::logger_index
 
     uint64_t get_last_seq_no();
 
-    int handle_log_index_control(std::string_view query);
+    int index_check_write(std::string_view query);
+
+    int index_check_open(std::string_view query);
+
+    int index_check_getattr(std::string_view query, struct stat *stbuf);
 } // namespace hpfs::audit::logger_index
 
 #endif

--- a/src/fusefs.cpp
+++ b/src/fusefs.cpp
@@ -84,7 +84,7 @@ namespace hpfs::fusefs
             return 0;
         }
 
-        // Check whether this is a index file write request.
+        // Check whether this is a index file control request.
         // 0 = Successfuly interpreted as a log index control request.
         // 1 = Request should be handled by the virtual fs.
         // <0 = Error code needs to be returned.
@@ -263,7 +263,7 @@ namespace hpfs::fusefs
 
     int fs_open(const char *full_path, struct fuse_file_info *fi)
     {
-        // Check whether this is a index file write request.
+        // Check whether this is a index file control request.
         // 0 = Successfuly interpreted as a log index control request.
         // 1 = Request should be handled by the virtual fs.
         // <0 = Error code needs to be returned.
@@ -310,7 +310,7 @@ namespace hpfs::fusefs
     int fs_write(const char *full_path, const char *buf, size_t size,
                  off_t offset, struct fuse_file_info *fi)
     {
-        // Check whether this is a index file write request.
+        // Check whether this is a index file control request.
         // 0 = Successfuly interpreted as a log index control request.
         // 1 = Request should be handled by the virtual fs.
         // <0 = Error code needs to be returned.

--- a/src/fusefs.cpp
+++ b/src/fusefs.cpp
@@ -322,7 +322,6 @@ namespace hpfs::fusefs
                 return size;
             else
                 return index_check_result;
-            return size;
         }
 
         const auto &[sess_name, res_path] = session::split_path(full_path);

--- a/src/hmap/hasher.cpp
+++ b/src/hmap/hasher.cpp
@@ -43,7 +43,7 @@ namespace hpfs::hmap::hasher
     std::ostream &operator<<(std::ostream &output, const h32 &h)
     {
         const uint8_t *buf = reinterpret_cast<const uint8_t *>(&h);
-        for (int i = 0; i < 32; i++) // Only print first 5 bytes in hex.
+        for (int i = 0; i < 5; i++) // Only print first 5 bytes in hex.
             output << std::hex << std::setfill('0') << std::setw(2) << (int)buf[i];
 
         return output;

--- a/src/hmap/hasher.cpp
+++ b/src/hmap/hasher.cpp
@@ -43,7 +43,7 @@ namespace hpfs::hmap::hasher
     std::ostream &operator<<(std::ostream &output, const h32 &h)
     {
         const uint8_t *buf = reinterpret_cast<const uint8_t *>(&h);
-        for (int i = 0; i < 5; i++) // Only print first 5 bytes in hex.
+        for (int i = 0; i < 32; i++) // Only print first 5 bytes in hex.
             output << std::hex << std::setfill('0') << std::setw(2) << (int)buf[i];
 
         return output;

--- a/src/hpfs.cpp
+++ b/src/hpfs.cpp
@@ -75,8 +75,8 @@ namespace hpfs
 
             if (run_ro_rw_session(argv[0]) == -1)
             {
-                merger::deinit();
                 audit::logger_index::deinit();
+                merger::deinit();
                 return -1;
             }
 

--- a/src/hpfs.hpp
+++ b/src/hpfs.hpp
@@ -32,6 +32,7 @@ namespace hpfs
         std::string hmap_dir;
         std::string trace_dir;
         std::string log_file_path;
+        std::string log_index_file_path;
         struct stat default_stat; // Stat used as a base stat for virtual entries.
     };
     extern hpfs_context ctx;

--- a/src/merger.cpp
+++ b/src/merger.cpp
@@ -9,7 +9,7 @@
 #include "merger.hpp"
 #include "util.hpp"
 #include "hpfs.hpp"
-#include "audit.hpp"
+#include "audit/audit.hpp"
 #include "tracelog.hpp"
 
 namespace hpfs::merger

--- a/src/merger.hpp
+++ b/src/merger.hpp
@@ -2,7 +2,7 @@
 #define _HPFS_MERGER_
 
 #include <vector>
-#include "audit.hpp"
+#include "audit/audit.hpp"
 
 namespace hpfs::merger
 {

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -9,7 +9,7 @@
 #include "hmap/tree.hpp"
 #include "hmap/query.hpp"
 #include "inodes.hpp"
-#include "audit.hpp"
+#include "audit/audit.hpp"
 #include "hpfs.hpp"
 #include "tracelog.hpp"
 

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -8,7 +8,7 @@
 #include "vfs/fuse_adapter.hpp"
 #include "hmap/tree.hpp"
 #include "hmap/query.hpp"
-#include "audit.hpp"
+#include "audit/audit.hpp"
 
 #define SESSION_READ_LOCK std::shared_lock lock(hpfs::session::sessions_mutex);
 #define SESSION_WRITE_LOCK std::unique_lock lock(hpfs::session::sessions_mutex);

--- a/src/vfs/fuse_adapter.cpp
+++ b/src/vfs/fuse_adapter.cpp
@@ -4,7 +4,6 @@
 #include "fuse_adapter.hpp"
 #include "virtual_filesystem.hpp"
 #include "../hmap/tree.hpp"
-#include "../audit.hpp"
 #include "../util.hpp"
 
 /**

--- a/src/vfs/fuse_adapter.hpp
+++ b/src/vfs/fuse_adapter.hpp
@@ -4,7 +4,7 @@
 #include <shared_mutex>
 #include "virtual_filesystem.hpp"
 #include "../hmap/tree.hpp"
-#include "../audit.hpp"
+#include "../audit/audit.hpp"
 
 namespace hpfs::vfs
 {

--- a/src/vfs/virtual_filesystem.cpp
+++ b/src/vfs/virtual_filesystem.cpp
@@ -12,7 +12,6 @@
 #include <optional>
 #include "vfs.hpp"
 #include "virtual_filesystem.hpp"
-#include "../audit.hpp"
 #include "../inodes.hpp"
 #include "../util.hpp"
 #include "../tracelog.hpp"

--- a/src/vfs/virtual_filesystem.hpp
+++ b/src/vfs/virtual_filesystem.hpp
@@ -5,7 +5,7 @@
 #include <mutex>
 #include "vfs.hpp"
 #include "seed_path_tracker.hpp"
-#include "../audit.hpp"
+#include "../audit/audit.hpp"
 
 namespace hpfs::vfs
 {


### PR DESCRIPTION
1. Interface to control hpfs log file.

- open
- getattr
- write

2. handling the control requests

3. Methods to

- Append log offset and the root hash to the index file
- Get latest root hash and the seq no from the index file