### PR TITLE
Interface to read log records from hpfs log

### DIFF
--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -375,7 +375,7 @@ namespace hpfs::audit
      * @param offset Log record offset to be read. If 0 current first record will be read.
      * @param next_offset Indicates the offset of next log record if read succesful or -1 if
      *                    no record available at 'offset'. If the record is the last record then next_offset is 0.
-     * @param record Contains the log record buffer if read successful.
+     * @param buf Contains the log record buffer if read successful.
      * @return 0 on successful read or no record available. -1 on error.
      */
     int audit_logger::read_log_record_buf_at(const off_t offset, off_t &next_offset, std::string &buf)
@@ -420,7 +420,7 @@ namespace hpfs::audit
         }
 
         // Reading the block data.
-        // Calculate total record length including block alignment padding.
+        // Calculate block offset including block alignment padding.
         const off_t block_data_offset = read_offset + BLOCK_END(buf_offset);
         if (rh.block_data_len > 0)
         {

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -370,6 +370,79 @@ namespace hpfs::audit
         return 0;
     }
 
+    /**
+     * Reads the log record indicated by the offset as a buffer if a record exists at that offset.
+     * @param offset Log record offset to be read. If 0 current first record will be read.
+     * @param next_offset Indicates the offset of next log record if read succesful or -1 if
+     *                    no record available at 'offset'. If the record is the last record then next_offset is 0.
+     * @param record Contains the log record buffer if read successful.
+     * @return 0 on successful read or no record available. -1 on error.
+     */
+    int audit_logger::read_log_record_buf_at(const off_t offset, off_t &next_offset, std::string &buf)
+    {
+        if (header.first_record == 0 || offset > header.last_record)
+        {
+            next_offset = -1;
+            return 0;
+        }
+
+        const off_t read_offset = offset == 0 ? header.first_record : offset;
+
+        // Reading the log header.
+        buf.resize(sizeof(log_record_header));
+        if (pread(fd, buf.data(), sizeof(log_record_header), read_offset) < sizeof(log_record_header))
+        {
+            LOG_ERROR << errno << ": Error reading log record header from log file.";
+            return -1;
+        }
+        size_t buf_offset = sizeof(log_record_header);
+
+        // Keeps a local copy of log record header to get data lengths.
+        const log_record_header rh = *(const log_record_header *)buf.data();
+
+        // Reading the vpath.
+        buf.resize(buf.length() + rh.vpath_len);
+        if (pread(fd, buf.data() + buf_offset, rh.vpath_len, read_offset + buf_offset) < rh.vpath_len)
+        {
+            LOG_ERROR << errno << ": Error reading log record vpath from log file.";
+            return -1;
+        }
+        buf_offset += rh.vpath_len;
+
+        // Reading the payload.
+        if (rh.payload_len > 0)
+        {
+            buf.resize(buf.length() + rh.payload_len);
+            if (pread(fd, buf.data() + buf_offset, rh.payload_len, read_offset + buf_offset) < rh.payload_len)
+            {
+                LOG_ERROR << errno << ": Error reading log record payload from log file.";
+                return -1;
+            }
+            buf_offset += rh.payload_len;
+        }
+
+        // Reading the block data.
+        // Calculate total record length including block alignment padding.
+        const off_t block_data_offset = read_offset + BLOCK_END(buf_offset);
+        if (rh.block_data_len > 0)
+        {
+            buf.resize(buf.length() + rh.block_data_len);
+            if (pread(fd, buf.data() + buf_offset, rh.block_data_len, block_data_offset) < rh.block_data_len)
+            {
+                LOG_ERROR << errno << ": Error reading log record block data from log file.";
+                return -1;
+            }
+            buf_offset += rh.block_data_len;
+        }
+
+        next_offset = block_data_offset + rh.block_data_len;
+        // If there's no more log records next offset is 0.
+        if (next_offset == eof)
+            next_offset = 0;
+
+        return 0;
+    }
+
     int audit_logger::read_payload(std::vector<uint8_t> &payload, const log_record &record)
     {
         if (record.payload_len > 0)

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -113,9 +113,9 @@ namespace hpfs::audit
         struct flock session_lock = {}; // Session lock placed on the log file.
 
         int init();
-        int init_log_header();
 
     public:
+        int init_log_header();
         static int create(std::optional<audit_logger> &logger, const LOG_MODE mode, std::string_view log_file_path);
         audit_logger(const LOG_MODE mode, std::string_view log_file_path);
         int get_fd();
@@ -128,6 +128,7 @@ namespace hpfs::audit
         off_t append_log(log_record_header &log_record, std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
                          const iovec *block_bufs = NULL, const int block_buf_count = 0);
         int read_log_at(const off_t offset, off_t &next_offset, log_record &record);
+        int read_log_record_buf_at(const off_t offset, off_t &next_offset, std::string &buf);
         int read_payload(std::vector<uint8_t> &payload, const log_record &record);
         int purge_log(const log_record &record);
         int update_log_record(const off_t log_rec_start_offset, const hmap::hasher::h32 root_hash, log_record_header &rh);

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -13,7 +13,7 @@ namespace hpfs::audit::logger_index
 {
     constexpr int FILE_PERMS = 0644;
     constexpr int INDEX_UPDATE_QUERY_LEN = 13;
-    constexpr int INDEX_UPDATE_QUERY_FULLSTOP_LEN = 13;
+    constexpr int INDEX_UPDATE_QUERY_FULLSTOP_LEN = 14;
     constexpr const char *INDEX_UPDATE_QUERY = "/::hpfs.index";
     constexpr const char *INDEX_UPDATE_QUERY_FULLSTOP = "/::hpfs.index.";
 
@@ -486,13 +486,13 @@ namespace hpfs::audit::logger_index
             return 0;
         }
         // Read or truncate calls will contains paramters.
-        else if (strncmp(query.data(), INDEX_UPDATE_QUERY_FULLSTOP, 14) == 0)
+        else if (strncmp(query.data(), INDEX_UPDATE_QUERY_FULLSTOP, INDEX_UPDATE_QUERY_FULLSTOP_LEN) == 0)
         {
             // If logger index isn't initialized return no entry.
             if (!initialized)
                 return -ENOENT;
             // Given path should contain a sequnce number.
-            if (query.size() > 14)
+            if (query.size() > INDEX_UPDATE_QUERY_FULLSTOP_LEN)
             {
                 if (fstat(fd, stbuf) == -1)
                 {

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -1,6 +1,5 @@
 
 #include "logger_index.hpp"
-#include "audit.hpp"
 #include "../tracelog.hpp"
 #include "../util.hpp"
 
@@ -13,8 +12,11 @@
 namespace hpfs::audit::logger_index
 {
     constexpr int FILE_PERMS = 0644;
+    constexpr int INDEX_UPDATE_QUERY_LEN = 13;
     constexpr const char *INDEX_UPDATE_QUERY = "/::hpfs.index";
     constexpr const char *INDEX_FILENAME_FULLSTOP = "/::hpfs.index.";
+
+    constexpr uint64_t MAX_LOG_READ_SIZE = 32901;
 
     int fd = -1;              // The index file fd used throughout the session.
     off_t eof = 0;            // End of file (End offset of index file).
@@ -164,22 +166,284 @@ namespace hpfs::audit::logger_index
     }
 
     /**
-     * Handles the log index control signals.
+     * Read the log offset of a given position.
+     * @param offset Log offset if requested position is equal to the eof offset will be 0.
+     * @param pos Position of the log.
+     * @return Returns -1 on error otherwise 0.
+    */
+    int read_offset(off_t &offset, const uint64_t pos)
+    {
+        // If logger isn't initialized show error.
+        if (!initialized)
+        {
+            LOG_ERROR << errno << ": Index hasn't been initialized properly.";
+            return -1;
+        }
+        else if (eof == 0)
+        {
+            LOG_ERROR << errno << ": Index hasn't been updated.";
+            return -1;
+        }
+
+        // Calculate offset position of the index.
+        const uint64_t index_offset = pos * (sizeof(uint64_t) + sizeof(hmap::hasher::h32));
+        // If the offset is end of file set offset 0.
+        if (index_offset == eof)
+        {
+            offset = 0;
+            return 0;
+        }
+        else if (index_offset > eof)
+            return -1;
+
+        // Reading the offset value as big endian by calculating the offset position from the sequence number.
+        uint8_t be_offset[8];
+        if (pread(fd, &be_offset, sizeof(be_offset), index_offset) < sizeof(be_offset))
+        {
+            LOG_ERROR << errno << ": Error reading log index file. " << pos;
+            return -1;
+        }
+
+        // Convert big endian value to unit64_t;
+        offset = util::uint64_from_bytes(be_offset);
+        return 0;
+    }
+
+    /**
+     * Read the hash of a given position.
+     * @param hash Hash at the given position.
+     * @param pos Position of the log.
+     * @return Returns -1 on error otherwise 0.
+    */
+    int read_hash(hmap::hasher::h32 &hash, const uint64_t pos)
+    {
+        // If logger isn't initialized show error.
+        if (!initialized)
+        {
+            LOG_ERROR << errno << ": Index hasn't been initialized properly.";
+            return -1;
+        }
+        else if (eof == 0)
+        {
+            LOG_ERROR << errno << ": Index hasn't been updated.";
+            return -1;
+        }
+
+        // Calculate offset position of the index.
+        const uint64_t index_offset = pos * (sizeof(uint64_t) + sizeof(hmap::hasher::h32));
+        if (index_offset >= eof)
+            return -1;
+
+        // Reading the hash value.
+        if (pread(fd, &hash, sizeof(hmap::hasher::h32), index_offset + sizeof(hmap::hasher::h32)) < sizeof(hmap::hasher::h32))
+        {
+            LOG_ERROR << errno << ": Error reading log index file. " << pos;
+            return -1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Reading the log records withing min and max seq_no range and populate them along with the seq_no.
+     * @param buf Buffer to populate logs.
+     * @param min_seq_no Minimum seq_no to start scanning if 0 start from the first record of the log.
+     * @param max_seq_no Maximum seq_no to stop scanning if 0 give the records until the end.
+     * @param max_size Max buffer size to read if 0 buffer size is unlimited.
+     * @return Returns 0 on success, -1 on error.
+    */
+    int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no, const uint64_t max_size)
+    {
+        // If logger isn't initialized show error.
+        if (!initialized)
+        {
+            LOG_ERROR << errno << ": Index hasn't been initialized properly.";
+            return -1;
+        }
+        else if (eof == 0)
+        {
+            LOG_ERROR << errno << ": Index hasn't been updated.";
+            return -1;
+        }
+        else if (max_seq_no > 0 && min_seq_no > max_seq_no)
+        {
+            LOG_ERROR << errno << ": min_seq_no cannot be greated than max_seq_no.";
+            return -1;
+        }
+
+        off_t current_offset, max_offset;
+
+        // If min seq no is 0 start collecting from the very begining.
+        if (min_seq_no == 0)
+            current_offset = 0;
+        
+        // If max seq mo is 0 collect until the end.
+        if (max_seq_no == 0)
+            max_offset = 0;
+
+        if (min_seq_no > 0 && read_offset(current_offset, min_seq_no - 1) == -1 ||
+            max_seq_no > 0 && read_offset(max_offset, max_seq_no - 1) == -1)
+            return -1;
+
+        std::string log_record;
+        uint64_t seq_no = min_seq_no;
+        off_t next_seq_no_offset;
+        // Take the offset if the frontmost seq_no log record.
+        // if current offset is 0 take the 1st seq_no log record's offset.
+        if (current_offset == 0)
+        {
+            if (read_offset(next_seq_no_offset, seq_no++) == -1)
+                return -1;
+        }
+        else
+            next_seq_no_offset = current_offset;
+
+        // Tempory buffer to keep the intermidiate records bitween seq_no log records.
+        // To ensure endpoint of the main buf is a seq_no log record.
+        std::string record_buf;
+
+        // Loop until the max_offset
+        while (max_offset == 0 || current_offset <= max_offset)
+        {
+            record_buf.resize(record_buf.length() + sizeof(seq_no));
+            // If we reached to a seq_no log record
+            const bool is_seq_no_log = (next_seq_no_offset == current_offset);
+            // If this is a seq_no log append seq_no to the buf and read the next seq_no record's offset.
+            // otherwise it's 0.
+            if (is_seq_no_log)
+            {
+                memcpy(record_buf.data() + record_buf.length() - sizeof(seq_no), &seq_no, sizeof(seq_no));
+                if (read_offset(next_seq_no_offset, seq_no++) == -1)
+                    return -1;
+            }
+            else
+                memset(record_buf.data() + record_buf.length() - sizeof(seq_no), 0, sizeof(seq_no));
+
+            // Read the log record buf at currect offset.
+            // After reading current_offset would be nect records offset.
+            if (logger->init_log_header() == -1 || logger->read_log_record_buf_at(current_offset, current_offset, log_record) == -1)
+                return -1;
+            record_buf.append(log_record);
+
+            // If reached the max_size limit break from the loop befor adding the temp buffer to main and return the collected buffer.
+            if (max_size != 0 && (buf.length() + record_buf.length()) > max_size)
+                break;
+
+            // If the current log record is a seq_no log record, Append collected to the main buffer and clean the temp buffer.
+            if (is_seq_no_log)
+            {
+                buf.append(record_buf);
+                record_buf.clear();
+                record_buf.resize(0);
+            }
+
+            // If we reached to the eof of the log file, break from the loop and return collected.
+            if (current_offset == 0)
+                break;
+        }
+
+        return 0;
+    }
+
+    // This is the test function to decorde the hpfs log read buffer.
+    /**
+     * Appending log records to hpfs log file.
+     * @param buf Buffer to append.
+     * @return Returns 0 on success, -1 on error.
+    */
+    int append_log_records(const char *buf, const size_t size)
+    {
+        off_t offset = 0;
+        while (offset < size)
+        {
+            const uint64_t *seq_no = (const uint64_t *)std::string_view(buf + offset, 8).data();
+            offset += 8;
+            LOG_ERROR << std::to_string(*seq_no);
+            const log_record_header *rh = (const log_record_header *)std::string_view(buf + offset, sizeof(log_record_header)).data();
+            offset += sizeof(log_record_header);
+            LOG_ERROR << rh->operation << " " << rh->root_hash.to_hex() << " " << rh->vpath_len << " " << rh->payload_len << " " << rh->block_data_len;
+            const std::string vpath = std::string(buf + offset, rh->vpath_len).data();
+            offset += rh->vpath_len;
+            LOG_ERROR << vpath;
+            if (rh->payload_len > 0)
+            {
+                const char *payload = (const char *)std::string_view(buf + offset, rh->payload_len).data();
+                offset += rh->payload_len;
+            }
+            if (rh->block_data_len > 0)
+            {
+                const char *block_data = (const char *)std::string_view(buf + offset, rh->block_data_len).data();
+                offset += rh->block_data_len;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Checks open request for any read.
      * @param query Query passed from the outside.
+     * @param buf Data buffer to be returned.
+     * @param size Read size.
      * @return 0 if request succesfully was interpreted by index control. 1 if the request
      *         should be passed through to the virtual fs. <0 on error.
     */
-    int index_check_write(std::string_view query)
+    int index_check_read(std::string_view query, char *buf, size_t *size)
     {
-        // If logger index isn't initialized return no entry.
-        if (query == INDEX_UPDATE_QUERY)
-            return initialized ? update_log_index() : -ENOENT;
+        if (strncmp(query.data(), INDEX_UPDATE_QUERY, INDEX_UPDATE_QUERY_LEN) == 0 && query.length() > INDEX_UPDATE_QUERY_LEN)
+        {
+            // If logger index isn't initialized return no entry.
+            if (!initialized)
+                return -ENOENT;
+
+            // Split the query by '.'.
+            const std::vector<std::string> params = util::split_string(query, ".");
+            if (params.size() != 4)
+                return -EFAULT;
+
+            uint64_t min_seq_no, max_seq_no;
+            if (util::stoull(params.at(2).data(), min_seq_no) == -1 || util::stoull(params.at(3).data(), max_seq_no) == -1)
+                return -EFAULT;
+
+            std::string records;
+            // We send the requested size limit to collect the logs.
+            if (read_log_records(records, min_seq_no, max_seq_no, MAX_LOG_READ_SIZE) == -1)
+                return -1;
+
+            // Then we resize size to the actual buffer size to return back.
+            *size = records.length();
+            memcpy(buf, records.c_str(), records.length());
+            return 0;
+        }
 
         return 1;
     }
 
     /**
-     * Handles the log index control signals.
+     * Checks open request for any write.
+     * @param query Query passed from the outside.
+     * @return 0 if request succesfully was interpreted by index control. 1 if the request
+     *         should be passed through to the virtual fs. <0 on error.
+    */
+    int index_check_write(std::string_view query, const char *buf, const size_t size)
+    {
+        // If logger index isn't initialized return no entry.
+        if (query == INDEX_UPDATE_QUERY && query.length() == INDEX_UPDATE_QUERY_LEN)
+        {
+            if (!initialized)
+                return -ENOENT;
+
+            if (size <= 1)
+                return update_log_index();
+            else
+                return append_log_records(buf, size);
+        }
+
+        return 1;
+    }
+
+    /**
+     * Checks open request for any index.
      * @param query Query passed from the outside.
      * @return 0 if request succesfully was interpreted by index control. 1 if the request
      *         should be passed through to the virtual fs. <0 on error.
@@ -187,7 +451,7 @@ namespace hpfs::audit::logger_index
     int index_check_open(std::string_view query)
     {
         // If logger index isn't initialized return no entry.
-        if (query == INDEX_UPDATE_QUERY)
+        if (strncmp(query.data(), INDEX_UPDATE_QUERY, INDEX_UPDATE_QUERY_LEN) == 0)
             return initialized ? 0 : -ENOENT;
 
         return 1;
@@ -202,7 +466,7 @@ namespace hpfs::audit::logger_index
      */
     int index_check_getattr(std::string_view query, struct stat *stbuf)
     {
-        if (query == INDEX_UPDATE_QUERY)
+        if (strncmp(query.data(), INDEX_UPDATE_QUERY, INDEX_UPDATE_QUERY_LEN) == 0)
         {
             // If logger index isn't initialized return no entry.
             if (!initialized)
@@ -213,6 +477,8 @@ namespace hpfs::audit::logger_index
                 LOG_ERROR << errno << ": Error in stat of index file.";
                 return -1;
             }
+
+            stbuf->st_size = MAX_LOG_READ_SIZE;
             return 0;
         }
         else if (strncmp(query.data(), INDEX_FILENAME_FULLSTOP, 14) == 0)

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -17,7 +17,7 @@ namespace hpfs::audit::logger_index
     constexpr const char *INDEX_UPDATE_QUERY = "/::hpfs.index";
     constexpr const char *INDEX_UPDATE_QUERY_FULLSTOP = "/::hpfs.index.";
 
-    constexpr uint64_t MAX_LOG_READ_SIZE = 32901;
+    constexpr uint64_t MAX_LOG_READ_SIZE = 1 * 1024 * 1024;
 
     int fd = -1;              // The index file fd used throughout the session.
     off_t eof = 0;            // End of file (End offset of index file).
@@ -414,7 +414,7 @@ namespace hpfs::audit::logger_index
 
             std::string records;
             // We send the requested size limit to collect the logs.
-            if (read_log_records(records, min_seq_no, max_seq_no, MAX_LOG_READ_SIZE) == -1)
+            if (read_log_records(records, min_seq_no, max_seq_no, *size) == -1)
                 return -1;
 
             // Then we resize size to the actual buffer size to return back.

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -19,11 +19,11 @@ namespace hpfs::audit::logger_index
 
     uint64_t get_last_seq_no();
 
-    int read_offset(off_t &offset, const uint64_t pos);
+    int read_offset(off_t &offset, const uint64_t seq_no);
 
-    int read_hash(hmap::hasher::h32 &hash, const uint64_t pos);
+    int read_hash(hmap::hasher::h32 &hash, const uint64_t seq_no);
 
-    int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
+    int read_log_records(char *buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
     
     int append_log_records(const char *buf, const size_t size);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <optional>
 #include <sys/stat.h>
+#include "audit.hpp"
 #include "../hmap/hasher.hpp"
 
 namespace hpfs::audit::logger_index
@@ -18,7 +19,17 @@ namespace hpfs::audit::logger_index
 
     uint64_t get_last_seq_no();
 
-    int index_check_write(std::string_view query);
+    int read_offset(off_t &offset, const uint64_t pos);
+
+    int read_hash(hmap::hasher::h32 &hash, const uint64_t pos);
+
+    int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
+    
+    int append_log_records(const char *buf, const size_t size);
+
+    int index_check_read(std::string_view query, char *buf, size_t *size);
+
+    int index_check_write(std::string_view query, const char *buf, const size_t size);
 
     int index_check_open(std::string_view query);
 
@@ -31,7 +42,7 @@ namespace hpfs::audit::logger_index
     int get_log_offset_from_index_file(off_t &log_offset, const uint64_t seq_no);
 
     off_t get_data_offset_of_index_file(const uint64_t seq_no);
-    
+
 } // namespace hpfs::audit::logger_index
 
 #endif

--- a/src/hmap/hasher.cpp
+++ b/src/hmap/hasher.cpp
@@ -43,7 +43,7 @@ namespace hpfs::hmap::hasher
     std::ostream &operator<<(std::ostream &output, const h32 &h)
     {
         const uint8_t *buf = reinterpret_cast<const uint8_t *>(&h);
-        for (int i = 0; i < 32; i++) // Only print first 5 bytes in hex.
+        for (int i = 0; i < 5; i++) // Only print first 5 bytes in hex.
             output << std::hex << std::setfill('0') << std::setw(2) << (int)buf[i];
 
         return output;

--- a/src/hmap/hasher.cpp
+++ b/src/hmap/hasher.cpp
@@ -43,7 +43,7 @@ namespace hpfs::hmap::hasher
     std::ostream &operator<<(std::ostream &output, const h32 &h)
     {
         const uint8_t *buf = reinterpret_cast<const uint8_t *>(&h);
-        for (int i = 0; i < 5; i++) // Only print first 5 bytes in hex.
+        for (int i = 0; i < 32; i++) // Only print first 5 bytes in hex.
             output << std::hex << std::setfill('0') << std::setw(2) << (int)buf[i];
 
         return output;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -171,4 +171,25 @@ namespace util
         return 0;
     }
 
+    /**
+     * Splits the provided query by given delimeter.
+     * @param s String value to be splited.
+     * @param delimiter Splitting delimiter.
+     * @return returns the list of resuling strings.
+     */
+    const std::vector<std::string> split_string(std::string_view s, std::string_view delimiter)
+    {
+        size_t pos = 0;
+        std::vector<std::string> list;
+        std::string value(s);
+        while ((pos = value.find(delimiter)) != std::string::npos)
+        {
+            list.push_back(value.substr(0, pos));
+            value.erase(0, pos + delimiter.length());
+        }
+        list.push_back(value);
+
+        return list;
+    }
+
 } // namespace util

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -172,10 +172,10 @@ namespace util
     }
 
     /**
-     * Splits the provided query by given delimeter.
+     * Splits the provided string by given delimeter.
      * @param s String value to be splited.
      * @param delimiter Splitting delimiter.
-     * @return returns the list of resuling strings.
+     * @return The list of resulting strings.
      */
     const std::vector<std::string> split_string(std::string_view s, std::string_view delimiter)
     {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -2,6 +2,7 @@
 #define _HPFS_UTIL_
 
 #include <string>
+#include <vector>
 
 // Write() data block size. We choose this to be the page size for mmap() page alignment.
 constexpr size_t BLOCK_SIZE = 4096;
@@ -28,6 +29,7 @@ namespace util
     void uint64_to_bytes(uint8_t *dest, const uint64_t x);
     uint64_t uint64_from_bytes(const uint8_t *data);
     int stoull(const std::string &str, uint64_t &result);
+    const std::vector<std::string> split_string(std::string_view s, std::string_view delimiter);
 
 } // namespace util
 


### PR DESCRIPTION
- hpfs API to read all the log records in a given seq_no range
- min_seq_no and max_seq_no needs to be provided withing the request
- Populate a buffer with log_record_header, vpath, payload, blockdata of all the records within the requested range
- Each log record includes a seq_no header, If a record is respective to a seq_no then header is the seq_no otherwise it's 0
- Test function to decode the response, (This can be used for future implementations)