### PR TITLE
Adding hpfs version to files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(hpfs
     src/vfs/virtual_filesystem.cpp
     src/vfs/seed_path_tracker.cpp
     src/vfs/fuse_adapter.cpp
+    src/version.cpp
     src/fusefs.cpp
     src/merger.cpp
     src/session.cpp

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -17,7 +17,6 @@
 namespace hpfs::audit
 {
     constexpr int FILE_PERMS = 0644;
-    constexpr uint16_t HPFS_VERSION = 1;
 
     int audit_logger::create(std::optional<audit_logger> &logger, const LOG_MODE mode, std::string_view log_file_path)
     {

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -43,8 +43,6 @@ namespace hpfs::audit
 
     struct log_header
     {
-        uint16_t version;
-
         // Begin offset of the first log record. 0 indicates there are no records.
         off_t first_record;
 

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -65,7 +65,7 @@ namespace hpfs::audit::logger_index
         else
         {
             // Open an already existing file.
-            fd = open(file_path.data(), O_RDWR, FILE_PERMS);
+            fd = open(file_path.data(), O_RDWR);
         }
         if (fd == -1)
         {

--- a/src/hmap/store.cpp
+++ b/src/hmap/store.cpp
@@ -10,6 +10,7 @@
 #include "../hpfs.hpp"
 #include "../tracelog.hpp"
 #include "../util.hpp"
+#include "../version.hpp"
 
 namespace hpfs::hmap::store
 {
@@ -108,13 +109,14 @@ namespace hpfs::hmap::store
 
         const uint8_t is_file = node_hmap.is_file ? 1 : 0;
 
-        iovec memsegs[5] = {{(void *)&is_file, sizeof(is_file)},
+        iovec memsegs[6] = {{(void *)version::HP_VERSION_BYTES, version::VERSION_BYTES_LEN},
+                            {(void *)&is_file, sizeof(is_file)},
                             {(void *)&node_hmap.node_hash, sizeof(hasher::h32)},
                             {(void *)&node_hmap.name_hash, sizeof(hasher::h32)},
                             {(void *)&node_hmap.meta_hash, sizeof(hasher::h32)},
                             {(void *)node_hmap.block_hashes.data(), sizeof(hasher::h32) * node_hmap.block_hashes.size()}};
 
-        if (writev(fd, memsegs, 5) == -1)
+        if (writev(fd, memsegs, 6) == -1)
         {
             LOG_ERROR << errno << ": Error in persist hmap writev. " << filename;
             close(fd);
@@ -165,7 +167,7 @@ namespace hpfs::hmap::store
                             {(void *)&node_hmap.meta_hash, sizeof(hasher::h32)},
                             {(void *)node_hmap.block_hashes.data(), sizeof(hasher::h32) * node_hmap.block_hashes.size()}};
 
-        if (readv(fd, memsegs, 5) == -1)
+        if (preadv(fd, memsegs, 5, version::VERSION_BYTES_LEN) == -1)
         {
             close(fd);
             LOG_ERROR << errno << ": Error in hmap cache file readv. " << cache_filename;

--- a/src/hpfs.cpp
+++ b/src/hpfs.cpp
@@ -11,6 +11,7 @@
 #include "audit/audit.hpp"
 #include "session.hpp"
 #include "audit/logger_index.hpp"
+#include "version.hpp"
 
 namespace hpfs
 {
@@ -40,7 +41,7 @@ namespace hpfs
                       << "hpfs fs [fsdir] [mountdir] merge=[true|false] trace=[debug|info|warn|error]\n";
             return -1;
         }
-        if (vaidate_context() == -1 || tracelog::init() == -1)
+        if (vaidate_context() == -1 || tracelog::init() == -1 || version::init() == -1)
             return -1;
 
         // Populate default stat using seed dir stat.

--- a/src/hpfs.cpp
+++ b/src/hpfs.cpp
@@ -41,7 +41,7 @@ namespace hpfs
                       << "hpfs fs [fsdir] [mountdir] merge=[true|false] trace=[debug|info|warn|error]\n";
             return -1;
         }
-        if (vaidate_context() == -1 || tracelog::init() == -1 || version::init() == -1)
+        if (version::init() == -1 || vaidate_context() == -1 || tracelog::init() == -1)
             return -1;
 
         // Populate default stat using seed dir stat.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -111,6 +111,28 @@ namespace util
         return 0;
     }
 
+    /**
+     * Convert the given uint16_t number to bytes in big endian format.
+     * @param dest Byte array pointer.
+     * @param x Number to be converted.
+    */
+    void uint16_to_bytes(uint8_t *dest, const uint16_t x)
+    {
+        dest[0] = (uint8_t)((x >> 8) & 0xff);
+        dest[1] = (uint8_t)((x >> 0) & 0xff);
+    }
+
+    /**
+     * Read the uint16_t number from the given byte array which is in big endian format.
+     * @param data Byte array pointer.
+     * @return The uint16_t number in the given byte array.
+    */
+    uint16_t uint16_from_bytes(const uint8_t *data)
+    {
+        return ((uint16_t)data[0] << 8) +
+               (uint16_t)data[1];
+    }
+
     void uint32_to_bytes(uint8_t *dest, const uint32_t x)
     {
         dest[0] = (uint8_t)((x >> 24) & 0xff);

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -24,6 +24,8 @@ namespace util
     const std::string get_name(std::string_view path);
     const std::string get_parent_path(std::string_view path);
     int create_dir_tree_recursive(std::string_view path);
+    void uint16_to_bytes(uint8_t *dest, const uint16_t x);
+    uint16_t uint16_from_bytes(const uint8_t *data);
     void uint32_to_bytes(uint8_t *dest, const uint32_t x);
     uint32_t uint32_from_bytes(const uint8_t *data);
     void uint64_to_bytes(uint8_t *dest, const uint64_t x);

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,7 +1,7 @@
+#include <iostream>
+#include <string.h>
 #include "version.hpp"
 #include "util.hpp"
-#include "tracelog.hpp"
-
 namespace version
 {
     // Binary representations of the version. (populated during version init)
@@ -33,7 +33,7 @@ namespace version
 
         if (end == std::string::npos)
         {
-            LOG_ERROR << "Invalid version " << version;
+            std::cerr << "Invalid version " << version << std::endl;
             return -1;
         }
 
@@ -44,7 +44,7 @@ namespace version
 
         if (end == std::string::npos)
         {
-            LOG_ERROR << "Invalid version " << version;
+            std::cerr << "Invalid version " << version << std::endl;
             return -1;
         }
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -1,0 +1,63 @@
+#include "version.hpp"
+#include "util.hpp"
+#include "tracelog.hpp"
+
+namespace version
+{
+    // Binary representations of the version. (populated during version init)
+    uint8_t HP_VERSION_BYTES[VERSION_BYTES_LEN];
+
+    int init()
+    {
+        // Generate version bytes.
+        if (set_version_bytes(HP_VERSION_BYTES, HPFS_VERSION) == -1)
+            return -1;
+
+        return 0;
+    }
+
+    /**
+     * Create 8 byte binary version from version string. First 6 bytes contains the 3 version components and the 
+     * next 2 bytes are reserved for future use.
+     * @param bytes Byte buffer to be populated with binary version data.
+     * @param version Version string.
+     * @return Returns -1 on error and 0 on success.
+    */
+    int set_version_bytes(uint8_t *bytes, std::string_view version)
+    {
+        memset(bytes, 0, VERSION_BYTES_LEN);
+
+        const std::string delimeter = ".";
+        size_t start = 0;
+        size_t end = version.find(delimeter);
+
+        if (end == std::string::npos)
+        {
+            LOG_ERROR << "Invalid version " << version;
+            return -1;
+        }
+
+        const uint16_t major = atoi(version.substr(start, end - start).data());
+
+        start = end + delimeter.length();
+        end = version.find(delimeter, start);
+
+        if (end == std::string::npos)
+        {
+            LOG_ERROR << "Invalid version " << version;
+            return -1;
+        }
+
+        const uint16_t minor = atoi(version.substr(start, end - start).data());
+        start = end + delimeter.length();
+        end = version.find(delimeter, start);
+
+        const uint16_t patch = atoi(version.substr(start).data());
+
+        util::uint16_to_bytes(&bytes[0], major);
+        util::uint16_to_bytes(&bytes[2], minor);
+        util::uint16_to_bytes(&bytes[4], patch);
+
+        return 0;
+    }
+}

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,0 +1,24 @@
+#ifndef _HPFS_VERSION_
+#define _HPFS_VERSION_
+
+#include <string_view>
+
+namespace version
+{
+    // HPFS version. Written to new files.
+    constexpr const char *HPFS_VERSION = "1.0.0";
+
+    // Version header size in bytes when serialized in binary format. (applies to hpfs version)
+    // 2 bytes each for 3 version components. 2 bytes reserved.
+    constexpr const size_t VERSION_BYTES_LEN = 8;
+
+    // Binary representations of the versions. (populated during version init)
+    extern uint8_t HP_VERSION_BYTES[VERSION_BYTES_LEN];
+
+    int init();
+
+    int set_version_bytes(uint8_t *bytes, std::string_view version);
+
+}
+
+#endif


### PR DESCRIPTION
Hpfs version is the same size and format as in HP core. (8 bytes, MAJOR.MINOR.PATCH)
Added version header to following files at the start.

- Hpfs log file.
  - Removed hpfs version from the header and added it separately at the beginning of the file. 
  - `<version header (8)><log header>` 
- Hpfs log index file.
- Hmap cache files.