### PR TITLE
Persisting hpfs log responses from hpcore

### DIFF
--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -558,7 +558,7 @@ namespace hpfs::audit
             log_record log_record;
             if (read_log_at(log_record_offset, truncate_offset, log_record) == -1)
             {
-                LOG_ERROR << errno << "Error reading log file at offset: " << log_record_offset;
+                LOG_ERROR << "Error reading log file at offset: " << log_record_offset;
                 release_lock(truncate_lock);
                 return -1;
             }

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -105,6 +105,7 @@ namespace hpfs::audit
             if (pwrite(fd, version::HP_VERSION_BYTES, version::VERSION_BYTES_LEN, 0) < version::VERSION_BYTES_LEN)
             {
                 LOG_ERROR << "Error adding version header to the log file";
+                release_lock(header_lock);
                 return -1;
             }   
             memset(&header, 0, sizeof(header));
@@ -118,6 +119,7 @@ namespace hpfs::audit
             eof = BLOCK_END(version::VERSION_BYTES_LEN + sizeof(header));
             if (ftruncate(fd, eof) == -1)
             {
+                release_lock(header_lock);
                 LOG_ERROR << errno << ": Error when truncating file with header.";
                 return -1;
             }

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -115,7 +115,7 @@ namespace hpfs::audit
                 return -1;
             }
 
-            eof = BLOCK_END(sizeof(header));
+            eof = BLOCK_END(version::VERSION_BYTES_LEN + sizeof(header));
             if (ftruncate(fd, eof) == -1)
             {
                 LOG_ERROR << errno << ": Error when truncating file with header.";

--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -107,7 +107,7 @@ namespace hpfs::audit
                 LOG_ERROR << "Error adding version header to the log file";
                 release_lock(header_lock);
                 return -1;
-            }   
+            }
             memset(&header, 0, sizeof(header));
             if (commit_header() == -1)
             {
@@ -521,18 +521,17 @@ namespace hpfs::audit
 
     /**
      * Truncate log file upto the given log file offset value.
-     * @param log_record_offset The offset where the log file is truncated.
-     * @param prev_ledger_log_record_offset The offset of the previous ledger log record. Search for previous record is perform from top if this is zero.
+     * @param log_record_offset The offset where the log file is truncated. This log record will be kept and rest well be truncated.
      * @return Returns 0 on success and -1 on error.
     */
-    int audit_logger::truncate_log_file(const off_t log_record_offset, const off_t prev_ledger_log_record_offset)
+    int audit_logger::truncate_log_file(const off_t log_record_offset)
     {
         if (mode != LOG_MODE::LOG_SYNC)
             return -1;
 
-        if (header.first_record == 0 || log_record_offset > header.last_record)
+        if (header.first_record == 0)
         {
-            // Empty log file or offset is beyond the last record's offset.
+            LOG_ERROR << "Invalid log record offset for truncation";
             return -1;
         }
 
@@ -544,53 +543,46 @@ namespace hpfs::audit
             return -1;
         }
 
+        off_t truncate_offset;
         // We are removing all the log records.
-        if (header.first_record == log_record_offset)
+        if (log_record_offset == 0)
         {
+            truncate_offset = header.first_record;
             header.first_record = 0;
             header.last_checkpoint = 0;
             header.last_record = 0;
         }
         else
         {
-            // Start searching for the last record that will remain after the truncation happens.
-            // The search is done before the real file truncation.
-            off_t cur_log_offset;
-            // If the given previous log record offset is zero means that the search should start from top.
-            if (prev_ledger_log_record_offset == 0)
-                cur_log_offset = header.first_record;
-            else
-                cur_log_offset = prev_ledger_log_record_offset;
-
-            off_t next_log_offset;
-            log_record rh;
-            do
+            log_record log_record;
+            if (read_log_at(log_record_offset, truncate_offset, log_record) == -1)
             {
-                if (read_log_at(cur_log_offset, next_log_offset, rh) == -1)
-                {
-                    LOG_ERROR << "Error reading log record for last log update at offset: " << prev_ledger_log_record_offset;
-                    release_lock(truncate_lock);
-                    return -1;
-                }
-                cur_log_offset = next_log_offset;
-            } while (next_log_offset == log_record_offset);
-
+                LOG_ERROR << errno << "Error reading log file at offset: " << log_record_offset;
+                return -1;
+            }
             // Update new last record offset.
-            header.last_record = log_record_offset - rh.size;
-
+            header.last_record = log_record_offset;
             // Update last checkpoint if the check point was in a truncated offset.
             if (header.last_checkpoint > header.last_record)
                 header.last_checkpoint = header.last_record;
         }
 
-        if (ftruncate(fd, log_record_offset) == -1) // Truncate the file.
+        if (truncate_offset > eof)
         {
-            LOG_ERROR << "Error truncating log file at offset: " << std::to_string(log_record_offset);
+            LOG_ERROR << "Invalid log record offset for truncation";
+            return -1;
+        }
+        else if (truncate_offset <= 0 || truncate_offset == eof)
+            return 0;
+
+        if (ftruncate(fd, truncate_offset) == -1) // Truncate the file.
+        {
+            LOG_ERROR << errno << ": Error truncating log file at offset: " << truncate_offset;
             release_lock(truncate_lock);
             return -1;
         }
 
-        eof = log_record_offset;
+        eof = truncate_offset;
 
         if (commit_header() == -1)
         {

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -130,7 +130,7 @@ namespace hpfs::audit
         int read_payload(std::vector<uint8_t> &payload, const log_record &record);
         int purge_log(const log_record &record);
         int update_log_record(const off_t log_rec_start_offset, const hmap::hasher::h32 root_hash, log_record_header &rh);
-        int truncate_log_file(const off_t log_record_offset, const off_t prev_ledger_log_record_offset);
+        int truncate_log_file(const off_t log_record_offset);
         ~audit_logger();
     };
 

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -369,7 +369,14 @@ namespace hpfs::audit::logger_index
 
             // If we reached to the eof of the log file, break from the loop and return collected.
             if (current_offset == 0)
+            {
+                // If we reach this point, it means requested max is beyond our log (Ex: max_seq_no = 0).
+                // So we append collected all the records up until to the end of our log. 
+                memcpy(buf + buf_length, record_buf.c_str(), record_buf.length());
+                buf_length += record_buf.length();
+                record_buf.clear();
                 break;
+            }
         }
 
         return buf_length;

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -822,9 +822,10 @@ namespace hpfs::audit::logger_index
         // Reaching this point means truncation is successful. Delete existing hmap and re-calculate.
 
         hmap::hasher::h32 root_hash;
-        if (htree->store.clear() == -1 ||                        // Clear the existing hash store.
-            htree->calculate_root_hash(root_hash, true) == -1 || // Calculate entire filesystem hash from scratch.
-            htree->store.persist_hash_maps() == -1)              // Persist calculated hashes to disk.
+        if (virt_fs->re_build_vfs() == -1 ||               // Clear and re-build vfs.
+            htree->store.clear() == -1 ||                  // Clear the existing hash store.
+            htree->calculate_root_hash(root_hash) == -1 || // Calculate entire filesystem hash from scratch.
+            htree->store.persist_hash_maps() == -1)        // Persist calculated hashes to disk.
         {
             LOG_ERROR << "Error re-calculating root hash after truncation.";
             return -1;

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -20,7 +20,7 @@ namespace hpfs::audit::logger_index
     constexpr const char *INDEX_UPDATE_QUERY = "/::hpfs.index";
     constexpr const char *INDEX_UPDATE_QUERY_FULLSTOP = "/::hpfs.index.";
 
-    constexpr uint64_t MAX_LOG_READ_SIZE = 1 * 1024 * 1024;
+    constexpr uint64_t MAX_LOG_READ_SIZE = 4 * 1024 * 1024; // 4MB
 
     int fd = -1;              // The index file fd used throughout the session.
     off_t eof = 0;            // End of file (End offset of index file).
@@ -371,7 +371,7 @@ namespace hpfs::audit::logger_index
             if (current_offset == 0)
             {
                 // If we reach this point, it means requested max is beyond our log (Ex: max_seq_no = 0).
-                // So we append collected all the records up until to the end of our log. 
+                // So we append collected all the records up until to the end of our log.
                 memcpy(buf + buf_length, record_buf.c_str(), record_buf.length());
                 buf_length += record_buf.length();
                 record_buf.clear();

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -8,7 +8,6 @@
 #include "../hmap/hasher.hpp"
 #include "../vfs/virtual_filesystem.hpp"
 #include "../hmap/tree.hpp"
-#include "../hmap/hasher.hpp"
 
 namespace hpfs::audit::logger_index
 {
@@ -21,8 +20,11 @@ namespace hpfs::audit::logger_index
         std::optional<audit::audit_logger> logger;
         std::optional<vfs::virtual_filesystem> virt_fs;
         std::optional<hmap::tree::hmap_tree> htree;
+        /* Because fuse is multithreaded and reading and writing processed by mulitple threads for several page blocks,
+        We use two local buffers to collect read and write logs and serve the reading logas and appending logs from these buffers.
+        This log read cannot be done from multiple threads by hpcore */
         std::string read_buf;  // Tempory buffer to keep reading result.
-        std::string write_buf; // Tempory buffer to collect writting logs.
+        std::string write_buf; // Tempory buffer to collect writing logs.
     };
 
     extern index_context index_ctx;
@@ -53,7 +55,7 @@ namespace hpfs::audit::logger_index
 
     int index_check_open(std::string_view query);
 
-    int index_check_release(std::string_view query);
+    int index_check_flush(std::string_view query);
 
     int index_check_getattr(std::string_view query, struct stat *stbuf);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -6,9 +6,27 @@
 #include <sys/stat.h>
 #include "audit.hpp"
 #include "../hmap/hasher.hpp"
+#include "../vfs/virtual_filesystem.hpp"
+#include "../hmap/tree.hpp"
+#include "../hmap/hasher.hpp"
 
 namespace hpfs::audit::logger_index
 {
+    struct index_context
+    {
+        int fd = -1;              // The index file fd used throughout the session.
+        off_t eof = 0;            // End of file (End offset of index file).
+        bool initialized = false; // Indicates that the index has been initialized properly.
+        std::string index_file_path;
+        std::optional<audit::audit_logger> logger;
+        std::optional<vfs::virtual_filesystem> virt_fs;
+        std::optional<hmap::tree::hmap_tree> htree;
+        std::string read_buf;  // Tempory buffer to keep reading result.
+        std::string write_buf; // Tempory buffer to collect writting logs.
+    };
+
+    extern index_context index_ctx;
+
     int init(std::string_view file_path);
 
     void deinit();
@@ -23,17 +41,19 @@ namespace hpfs::audit::logger_index
 
     int read_hash(hmap::hasher::h32 &hash, const uint64_t seq_no);
 
-    int read_log_records(char *buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
-    
+    int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
+
     int append_log_records(const char *buf, const size_t size);
 
-    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, const std::vector<uint8_t> &payload, const std::vector<uint8_t> &block_data);
+    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, std::string_view payload, std::string_view block_data);
 
-    int index_check_read(std::string_view query, char *buf, size_t *size);
+    int index_check_read(std::string_view query, char *buf, size_t *size, const off_t offset);
 
-    int index_check_write(std::string_view query, const char *buf, const size_t size);
+    int index_check_write(std::string_view query, const char *buf, size_t *size, const off_t offset);
 
     int index_check_open(std::string_view query);
+
+    int index_check_release(std::string_view query);
 
     int index_check_getattr(std::string_view query, struct stat *stbuf);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -33,9 +33,11 @@ namespace hpfs::audit::logger_index
 
     void deinit();
 
-    int update_log_index();
+    int update_log_index(const uint64_t seq_no);
 
     int read_last_root_hash(hmap::hasher::h32 &root_hash);
+
+    int get_last_index_data(off_t &offset, hmap::hasher::h32 &root_hash);
 
     uint64_t get_last_seq_no();
 
@@ -47,7 +49,7 @@ namespace hpfs::audit::logger_index
 
     int append_log_records(const char *buf, const size_t size);
 
-    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, std::string_view payload, std::string_view block_data);
+    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, std::string_view payload, std::string_view block_data, off_t &log_offset, hmap::hasher::h32 &root_hash);
 
     int index_check_read(std::string_view query, char *buf, size_t *size, const off_t offset);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -25,6 +25,14 @@ namespace hpfs::audit::logger_index
         This log read cannot be done from multiple threads by hpcore */
         std::string read_buf;  // Tempory buffer to keep reading result.
         std::string write_buf; // Tempory buffer to collect writing logs.
+
+        void reset()
+        {
+            logger.reset();
+            virt_fs.reset();
+            htree.reset();
+            initialized = false;
+        }
     };
 
     extern index_context index_ctx;

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -27,6 +27,8 @@ namespace hpfs::audit::logger_index
     
     int append_log_records(const char *buf, const size_t size);
 
+    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, const std::vector<uint8_t> &payload, const std::vector<uint8_t> &block_data);
+
     int index_check_read(std::string_view query, char *buf, size_t *size);
 
     int index_check_write(std::string_view query, const char *buf, const size_t size);

--- a/src/fusefs.cpp
+++ b/src/fusefs.cpp
@@ -297,7 +297,7 @@ namespace hpfs::fusefs
         // 1 = Request should be handled by the virtual fs.
         // <0 = Error code needs to be returned.
         // Only is this is successfully interprited buf and size will be populated otherwise they will be kept as it is.
-        const int index_check_result = audit::logger_index::index_check_read(full_path, buf, &size);
+        const int index_check_result = audit::logger_index::index_check_read(full_path, buf, &size, offset);
         if (index_check_result < 1)
         {
             // If the read is success send the size as the response.
@@ -329,10 +329,10 @@ namespace hpfs::fusefs
         // 0 = Successfuly interpreted as a log index control request.
         // 1 = Request should be handled by the virtual fs.
         // <0 = Error code needs to be returned.
-        const int index_check_result = audit::logger_index::index_check_write(full_path, buf, size);
+        const int index_check_result = audit::logger_index::index_check_write(full_path, buf, &size, offset);
         if (index_check_result < 1)
         {
-            // If the write is success send the size as a dummy.
+            // If the write is success send the size as the response.
             if (index_check_result == 0)
                 return size;
             else
@@ -364,6 +364,13 @@ namespace hpfs::fusefs
 
     int fs_release(const char *full_path, struct fuse_file_info *fi)
     {
+        // Check whether this is a index file control request.
+        // 0 = Successfuly interpreted as a log index control request.
+        // 1 = Request should be handled by the virtual fs.
+        // <0 = Error code needs to be returned.
+        const int index_check_result = audit::logger_index::index_check_release(full_path);
+        // Even if this is handled by the index check we let the rest to proceed.
+
         if (fi->fh > 0)
             close(fi->fh);
         return 0;

--- a/src/hmap/store.cpp
+++ b/src/hmap/store.cpp
@@ -190,4 +190,20 @@ namespace hpfs::hmap::store
         return hpfs::ctx.hmap_dir + vpath;
     }
 
+    /**
+     * Clear existing hash store.
+     * @return -1 on error and 0 on success.
+    */
+    int hmap_store::clear()
+    {
+        if (util::remove_directory_recursively(hpfs::ctx.hmap_dir) == -1)
+        {
+            LOG_ERROR << "Error cleaning persisted hmap files after truncation";
+            return -1;
+        }
+        hash_map.clear();
+        dirty_vpaths.clear();
+        return 0;
+    }
+
 } // namespace hpfs::hmap::store

--- a/src/hmap/store.hpp
+++ b/src/hmap/store.hpp
@@ -38,6 +38,7 @@ namespace hpfs::hmap::store
         void insert_hash_map(const std::string &vpath, vnode_hmap &&node_hmap);
         int move_hash_map_cache(const std::string &from_vpath, const std::string &to_vpath, const bool is_dir);
         int persist_hash_maps();
+        int clear();
     };
 } // namespace hpfs::hmap::store
 

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -49,7 +49,7 @@ namespace hpfs::hmap::tree
         {
             hasher::h32 root_hash;
             // Calculate entire filesystem hash from scratch.
-            if (calculate_root_hash(root_hash, false) == -1)
+            if (calculate_root_hash(root_hash) == -1)
                 return -1;
             LOG_INFO << "Calculated root hash: " << root_hash;
         }
@@ -372,13 +372,10 @@ namespace hpfs::hmap::tree
     /**
      * Build the hash tree from scratch.
      * @param root_hash The calculated root hash.
-     * @param build_vfs The need to build the vfs before calculating hashes.
      * @return -1 on error and 0 on success.
     */
-    int hmap_tree::calculate_root_hash(hasher::h32 &root_hash, const bool build_vfs)
+    int hmap_tree::calculate_root_hash(hasher::h32 &root_hash)
     {
-        if (build_vfs)
-            virt_fs.build_vfs();
         // Calculate entire filesystem hash from scratch.
         if (calculate_dir_hash(root_hash, ROOT_VPATH) == -1)
             return -1;

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -47,11 +47,10 @@ namespace hpfs::hmap::tree
         const store::vnode_hmap *root_hmap = store.find_hash_map(ROOT_VPATH);
         if (root_hmap == NULL)
         {
-            // Calculate entire filesystem hash from scratch.
             hasher::h32 root_hash;
-            if (calculate_dir_hash(root_hash, ROOT_VPATH) == -1)
+            // Calculate entire filesystem hash from scratch.
+            if (calculate_root_hash(root_hash, false) == -1)
                 return -1;
-
             LOG_INFO << "Calculated root hash: " << root_hash;
         }
         else
@@ -368,6 +367,23 @@ namespace hpfs::hmap::tree
         uint8_t buf[4];
         util::uint32_to_bytes(buf, vn.st.st_mode);
         hasher::hash_buf(vn_hmap.meta_hash, std::string_view((const char *)buf, sizeof(buf)));
+    }
+
+    /**
+     * Build the hash tree from scratch.
+     * @param root_hash The calculated root hash.
+     * @param build_vfs The need to build the vfs before calculating hashes.
+     * @return -1 on error and 0 on success.
+    */
+    int hmap_tree::calculate_root_hash(hasher::h32 &root_hash, const bool build_vfs)
+    {
+        if (build_vfs)
+            virt_fs.build_vfs();
+        // Calculate entire filesystem hash from scratch.
+        if (calculate_dir_hash(root_hash, ROOT_VPATH) == -1)
+            return -1;
+
+        return 0;
     }
 
     hmap_tree::~hmap_tree()

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -16,12 +16,12 @@ namespace hpfs::hmap::tree
     private:
         bool moved = false;
         bool initialized = false; // Indicates that the instance has been initialized properly.
+        store::hmap_store store;
         hpfs::vfs::virtual_filesystem &virt_fs;
         void generate_name_hash(store::vnode_hmap &vn_hmap, std::string_view vpath);
         void generate_meta_hash(store::vnode_hmap &vn_hmap, const vfs::vnode &vn);
 
     public:
-        store::hmap_store store;
         int init();
         static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs);
         hmap_tree(hpfs::vfs::virtual_filesystem &virt_fs);
@@ -38,7 +38,8 @@ namespace hpfs::hmap::tree
         int apply_vnode_delete(const std::string &vpath);
         int apply_vnode_rename(const std::string &from_vpath, const std::string &to_vpath, const bool is_dir);
         hmap::hasher::h32 get_root_hash();
-        int calculate_root_hash(hasher::h32 &root_hash);
+        int re_build_hash_maps(hasher::h32 &root_hash);
+        int persist_hash_maps();
         ~hmap_tree();
     };
 

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -38,6 +38,7 @@ namespace hpfs::hmap::tree
         int apply_vnode_delete(const std::string &vpath);
         int apply_vnode_rename(const std::string &from_vpath, const std::string &to_vpath, const bool is_dir);
         hmap::hasher::h32 get_root_hash();
+        int calculate_root_hash(hasher::h32 &root_hash, const bool build_vfs);
         ~hmap_tree();
     };
 

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -38,7 +38,7 @@ namespace hpfs::hmap::tree
         int apply_vnode_delete(const std::string &vpath);
         int apply_vnode_rename(const std::string &from_vpath, const std::string &to_vpath, const bool is_dir);
         hmap::hasher::h32 get_root_hash();
-        int calculate_root_hash(hasher::h32 &root_hash, const bool build_vfs);
+        int calculate_root_hash(hasher::h32 &root_hash);
         ~hmap_tree();
     };
 

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -16,13 +16,13 @@ namespace hpfs::hmap::tree
     private:
         bool moved = false;
         bool initialized = false; // Indicates that the instance has been initialized properly.
-        store::hmap_store store;
         hpfs::vfs::virtual_filesystem &virt_fs;
-        int init();
         void generate_name_hash(store::vnode_hmap &vn_hmap, std::string_view vpath);
         void generate_meta_hash(store::vnode_hmap &vn_hmap, const vfs::vnode &vn);
 
     public:
+        store::hmap_store store;
+        int init();
         static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs);
         hmap_tree(hpfs::vfs::virtual_filesystem &virt_fs);
         int get_vnode_hmap(store::vnode_hmap **node_hmap, const std::string &vpath);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <signal.h>
 #include <libgen.h>
+#include <ftw.h>
 #include "util.hpp"
 #include "tracelog.hpp"
 
@@ -212,6 +213,19 @@ namespace util
         list.push_back(value);
 
         return list;
+    }
+
+    /**
+     * Remove a directory recursively with it's content. FTW_DEPTH is provided so all of the files and subdirectories within
+     * The path will be processed. FTW_PHYS is provided so symbolic links won't be followed.
+     */
+    int remove_directory_recursively(std::string_view dir_path)
+    {
+        return nftw(
+            dir_path.data(), [](const char *fpath, const struct stat *sb, int typeflag, struct FTW *ftwbuf) {
+                return remove(fpath);
+            },
+            1, FTW_DEPTH | FTW_PHYS);
     }
 
 } // namespace util

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -32,6 +32,7 @@ namespace util
     uint64_t uint64_from_bytes(const uint8_t *data);
     int stoull(const std::string &str, uint64_t &result);
     const std::vector<std::string> split_string(std::string_view s, std::string_view delimiter);
+    int remove_directory_recursively(std::string_view dir_path);
 
 } // namespace util
 

--- a/src/vfs/virtual_filesystem.hpp
+++ b/src/vfs/virtual_filesystem.hpp
@@ -41,7 +41,7 @@ namespace hpfs::vfs
 
     public:
         static int create(std::optional<virtual_filesystem> &virt_fs, const bool readonly, std::string_view seed_dir,
-                                                        hpfs::audit::audit_logger &logger);
+                          hpfs::audit::audit_logger &logger);
         virtual_filesystem(const bool readonly, std::string_view seed_dir, hpfs::audit::audit_logger &logger);
         int get_vnode(const std::string &vpath, vnode **vn);
         int build_vfs();
@@ -50,6 +50,7 @@ namespace hpfs::vfs
                                      off_t &block_buf_start, off_t &block_buf_end,
                                      const char *buf, const size_t wr_size,
                                      const off_t wr_start, const size_t fsize, uint8_t *mmap_ptr);
+        int re_build_vfs();
         ~virtual_filesystem();
     };
 


### PR DESCRIPTION
- Verifying the continuity of log index file and updating respectively.
- Fixed issue in fs read write by multiple threads by maintaining temporary read write buffers.
- Fixed log record truncation issue.
- Rebuilding hash tree after log file truncation.