### PR TITLE
Fixed full history syncing issues

### DIFF
--- a/src/audit/audit.cpp
+++ b/src/audit/audit.cpp
@@ -215,7 +215,7 @@ namespace hpfs::audit
         return 0;
     }
 
-    int audit_logger::reset_eof()
+    int audit_logger::update_eof()
     {
         struct stat st;
         if (fstat(fd, &st) == -1)

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -31,15 +31,17 @@ namespace hpfs::audit
         RW,
         MERGE,
         PRINT,
-        LOG_SYNC
+        LOG_SYNC_WRITE,
+        LOG_SYNC_READ
     };
 
     enum LOCK_TYPE
     {
-        SESSION_LOCK, // Used by RO/RW session to indicate existance of session.
-        UPDATE_LOCK,  // Used by RW session to make updates to the header.
-        MERGE_LOCK,   // Used by MERGE session to acquire exclusive access to the log.
-        SYNC_LOCK     // Used by LOG_SYNC session to acquire exclusive access to the log.
+        SESSION_LOCK,    // Used by RO/RW session to indicate existance of session.
+        UPDATE_LOCK,     // Used by RW session to make updates to the header.
+        MERGE_LOCK,      // Used by MERGE session to acquire exclusive access to the log.
+        SYNC_WRITE_LOCK, // Used by LOG_SYNC_WRITE session to acquire exclusive access to the log.
+        SYNC_READ_LOCK   // Used by LOG_SYNC_READ session to acquire non exclusive read access to the log.
     };
 
     struct log_header
@@ -158,7 +160,6 @@ namespace hpfs::audit
         int set_lock(struct flock &lock, const LOCK_TYPE type);
         int release_lock(struct flock &lock);
         int read_header();
-        int update_eof();
         int commit_header();
         off_t append_log(log_record_header &log_record, std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
                          const iovec *data_bufs = NULL, const int data_buf_count = 0);

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -158,7 +158,7 @@ namespace hpfs::audit
         int set_lock(struct flock &lock, const LOCK_TYPE type);
         int release_lock(struct flock &lock);
         int read_header();
-        int reset_eof();
+        int update_eof();
         int commit_header();
         off_t append_log(log_record_header &log_record, std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
                          const iovec *data_bufs = NULL, const int data_buf_count = 0);

--- a/src/audit/audit.hpp
+++ b/src/audit/audit.hpp
@@ -158,6 +158,7 @@ namespace hpfs::audit
         int set_lock(struct flock &lock, const LOCK_TYPE type);
         int release_lock(struct flock &lock);
         int read_header();
+        int reset_eof();
         int commit_header();
         off_t append_log(log_record_header &log_record, std::string_view vpath, const FS_OPERATION operation, const iovec *payload_buf = NULL,
                          const iovec *data_bufs = NULL, const int data_buf_count = 0);

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -42,17 +42,10 @@ namespace hpfs::audit::logger_index
         // First initialize the logger.
         if (audit::audit_logger::create(index_ctx.logger, audit::LOG_MODE::LOG_SYNC, ctx.log_file_path) == -1 ||
             vfs::virtual_filesystem::create(index_ctx.virt_fs, false, ctx.seed_dir, index_ctx.logger.value()) == -1 ||
-            hmap::tree::hmap_tree::create(index_ctx.htree, index_ctx.virt_fs.value()) == -1)
+            hmap::tree::hmap_tree::create(index_ctx.htree, index_ctx.virt_fs.value(), false) == -1)
         {
             LOG_ERROR << "Error initializing log index.";
             index_ctx.reset();
-            return -1;
-        }
-
-        // Once loaded the hash map, persist dirty hashes to the cache file.
-        if (index_ctx.htree->persist_hash_maps() == -1)
-        {
-            LOG_ERROR << errno << ": Error persisting the htree.";
             return -1;
         }
 

--- a/src/audit/logger_index.cpp
+++ b/src/audit/logger_index.cpp
@@ -49,6 +49,13 @@ namespace hpfs::audit::logger_index
             return -1;
         }
 
+        // Once loaded the hash map, persist dirty hashes to the cache file.
+        if (index_ctx.htree->persist_hash_maps() == -1)
+        {
+            LOG_ERROR << errno << ": Error persisting the htree.";
+            return -1;
+        }
+
         // Open or create the index file.
         if (!util::is_file_exists(file_path))
         {

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -17,21 +17,11 @@ namespace hpfs::audit::logger_index
         off_t eof = 0;            // End of file (End offset of index file).
         bool initialized = false; // Indicates that the index has been initialized properly.
         std::string index_file_path;
-        std::optional<audit::audit_logger> logger;
-        std::optional<vfs::virtual_filesystem> virt_fs;
-        std::optional<hmap::tree::hmap_tree> htree;
         /* Because fuse is multithreaded and reading and writing processed by mulitple threads for several page blocks,
         We use two local buffers to collect read and write logs and serve the reading logas and appending logs from these buffers.
         This log read cannot be done from multiple threads by hpcore */
         std::string read_buf;  // Tempory buffer to keep reading result.
         std::string write_buf; // Tempory buffer to collect writing logs.
-
-        void reset_optional_variables()
-        {
-            logger.reset();
-            virt_fs.reset();
-            htree.reset();
-        }
     };
 
     extern index_context index_ctx;
@@ -56,7 +46,8 @@ namespace hpfs::audit::logger_index
 
     int append_log_records(const char *buf, const size_t size);
 
-    int persist_log_record(const uint64_t seq_no, const audit::FS_OPERATION op, const std::string &vpath, std::string_view payload, std::string_view block_data, off_t &log_offset, hmap::hasher::h32 &root_hash);
+    int persist_log_record(audit::audit_logger &logger, vfs::virtual_filesystem &virt_fs, hmap::tree::hmap_tree &htree, const uint64_t seq_no, const audit::FS_OPERATION op,
+                           const std::string &vpath, std::string_view payload, std::string_view block_data, off_t &log_offset, hmap::hasher::h32 &root_hash);
 
     int index_check_read(std::string_view query, char *buf, size_t *size, const off_t offset);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -53,7 +53,7 @@ namespace hpfs::audit::logger_index
 
     int read_hash(hmap::hasher::h32 &hash, const uint64_t seq_no);
 
-    int reset_logger();
+    int update_logger_info();
 
     int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -26,12 +26,11 @@ namespace hpfs::audit::logger_index
         std::string read_buf;  // Tempory buffer to keep reading result.
         std::string write_buf; // Tempory buffer to collect writing logs.
 
-        void reset()
+        void reset_optional_variables()
         {
             logger.reset();
             virt_fs.reset();
             htree.reset();
-            initialized = false;
         }
     };
 
@@ -52,8 +51,6 @@ namespace hpfs::audit::logger_index
     int read_offset(off_t &offset, const uint64_t seq_no);
 
     int read_hash(hmap::hasher::h32 &hash, const uint64_t seq_no);
-
-    int update_logger_info();
 
     int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -69,7 +69,7 @@ namespace hpfs::audit::logger_index
 
     int index_check_getattr(std::string_view query, struct stat *stbuf);
 
-    int index_check_truncate(const char *path);
+    int index_check_truncate(std::string_view query);
 
     int truncate_log_and_index_file(const uint64_t seq_no);
 

--- a/src/audit/logger_index.hpp
+++ b/src/audit/logger_index.hpp
@@ -53,6 +53,8 @@ namespace hpfs::audit::logger_index
 
     int read_hash(hmap::hasher::h32 &hash, const uint64_t seq_no);
 
+    int reset_logger();
+
     int read_log_records(std::string &buf, const uint64_t min_seq_no, const uint64_t max_seq_no = 0, const uint64_t max_size = 0);
 
     int append_log_records(const char *buf, const size_t size);

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -23,7 +23,7 @@ namespace hpfs::hmap::tree
     constexpr size_t BLOCK_SIZE = 4194304; // 4MB
     constexpr const char *ROOT_VPATH = "/";
 
-    int hmap_tree::create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs, const bool persist_on_destruction)
+    int hmap_tree::create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs)
     {
         tree.emplace(virt_fs);
         if (tree->init() == -1)
@@ -31,7 +31,6 @@ namespace hpfs::hmap::tree
             tree.reset();
             return -1;
         }
-        tree->persist_on_destruction = persist_on_destruction;
 
         return 0;
     }
@@ -387,18 +386,9 @@ namespace hpfs::hmap::tree
         return 0;
     }
 
-    /**
-     * Persist hash map to the disk.
-     * @return -1 on error and 0 on success.
-    */
-    int hmap_tree::persist_hash_maps()
-    {
-        return store.persist_hash_maps();
-    }
-
     hmap_tree::~hmap_tree()
     {
-        if (initialized && !moved && persist_on_destruction)
+        if (initialized && !moved)
         {
             // Persist any hash map updates to the disk.
             store.persist_hash_maps();

--- a/src/hmap/tree.cpp
+++ b/src/hmap/tree.cpp
@@ -23,7 +23,7 @@ namespace hpfs::hmap::tree
     constexpr size_t BLOCK_SIZE = 4194304; // 4MB
     constexpr const char *ROOT_VPATH = "/";
 
-    int hmap_tree::create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs)
+    int hmap_tree::create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs, const bool persist_on_destruction)
     {
         tree.emplace(virt_fs);
         if (tree->init() == -1)
@@ -31,6 +31,7 @@ namespace hpfs::hmap::tree
             tree.reset();
             return -1;
         }
+        tree->persist_on_destruction = persist_on_destruction;
 
         return 0;
     }
@@ -397,7 +398,7 @@ namespace hpfs::hmap::tree
 
     hmap_tree::~hmap_tree()
     {
-        if (initialized && !moved)
+        if (initialized && !moved && persist_on_destruction)
         {
             // Persist any hash map updates to the disk.
             store.persist_hash_maps();

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -16,7 +16,6 @@ namespace hpfs::hmap::tree
     private:
         bool moved = false;
         bool initialized = false; // Indicates that the instance has been initialized properly.
-        bool persist_on_destruction = false; // Indicates that hash tree needs to be persisted on destrcution. 
         store::hmap_store store;
         hpfs::vfs::virtual_filesystem &virt_fs;
         void generate_name_hash(store::vnode_hmap &vn_hmap, std::string_view vpath);
@@ -24,7 +23,7 @@ namespace hpfs::hmap::tree
 
     public:
         int init();
-        static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs, const bool persist_on_destruction = true);
+        static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs);
         hmap_tree(hpfs::vfs::virtual_filesystem &virt_fs);
         int get_vnode_hmap(store::vnode_hmap **node_hmap, const std::string &vpath);
         int calculate_dir_hash(hasher::h32 &node_hash, const std::string &vpath);
@@ -40,7 +39,6 @@ namespace hpfs::hmap::tree
         int apply_vnode_rename(const std::string &from_vpath, const std::string &to_vpath, const bool is_dir);
         hmap::hasher::h32 get_root_hash();
         int re_build_hash_maps(hasher::h32 &root_hash);
-        int persist_hash_maps();
         ~hmap_tree();
     };
 

--- a/src/hmap/tree.hpp
+++ b/src/hmap/tree.hpp
@@ -16,6 +16,7 @@ namespace hpfs::hmap::tree
     private:
         bool moved = false;
         bool initialized = false; // Indicates that the instance has been initialized properly.
+        bool persist_on_destruction = false; // Indicates that hash tree needs to be persisted on destrcution. 
         store::hmap_store store;
         hpfs::vfs::virtual_filesystem &virt_fs;
         void generate_name_hash(store::vnode_hmap &vn_hmap, std::string_view vpath);
@@ -23,7 +24,7 @@ namespace hpfs::hmap::tree
 
     public:
         int init();
-        static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs);
+        static int create(std::optional<hmap_tree> &tree, hpfs::vfs::virtual_filesystem &virt_fs, const bool persist_on_destruction = true);
         hmap_tree(hpfs::vfs::virtual_filesystem &virt_fs);
         int get_vnode_hmap(store::vnode_hmap **node_hmap, const std::string &vpath);
         int calculate_dir_hash(hasher::h32 &node_hash, const std::string &vpath);


### PR DESCRIPTION
- Refactored logger operation file name checks
- Stop persisting hmap in htree object destructor for log_index
- Fixed logger instance local variable update issues.
